### PR TITLE
JJUG CCC用問い合わせフォームを追加

### DIFF
--- a/content/page/ccc-contact.md
+++ b/content/page/ccc-contact.md
@@ -1,0 +1,13 @@
+---
+title: "JJUG CCC お問い合わせ"
+---
+
+お気付きの点がありましたらぜひご連絡ください。
+
+### お問い合わせ
+JJUGのこと、JJUG CCCのこと、CoCに関することなど何でも結構です。  
+[こちら](https://jjug.doorkeeper.jp/contact/new) よりご連絡ください。
+
+### 匿名でのご報告
+[CoC]() に関して、匿名でのご報告を希望される場合は  
+[こちら](https://docs.google.com/forms/d/e/1FAIpQLSceWm0xbNJe4ddKXr5UO90Gz5pOnrmQ1t8ilFa2vTIcySC8Rg/viewform?usp=sf_link) よりご連絡ください。

--- a/content/page/ccc-contact.md
+++ b/content/page/ccc-contact.md
@@ -9,5 +9,5 @@ JJUGのこと、JJUG CCCのこと、CoCに関することなど何でも結構�
 [こちら](https://jjug.doorkeeper.jp/contact/new) よりご連絡ください。
 
 ### 匿名でのご報告
-[CoC]() に関して、匿名でのご報告を希望される場合は  
+[CoC](https://ccc2020fall.java-users.jp) に関して、匿名でのご報告を希望される場合は  
 [こちら](https://docs.google.com/forms/d/e/1FAIpQLSceWm0xbNJe4ddKXr5UO90Gz5pOnrmQ1t8ilFa2vTIcySC8Rg/viewform?usp=sf_link) よりご連絡ください。


### PR DESCRIPTION
まず前提として、  
非匿名の問い合わせは内容何でもOK、匿名はCoCについて
という認識で合っているでしょうか？

それで問題なければ次のような感じでいかがでしょう。
あくまでJJUG CCC用のページということでトップやメニューからのリンクはなし、
pathにも`ccc-`と入れております。
https://www.java-users.jp/page/ccc-contact/

![image](https://user-images.githubusercontent.com/8938191/98337694-5c1deb00-204c-11eb-93c6-3af8c1ff185e.png)