### PR TITLE
ハラスメント報告フォームのURLが機能していなかったため更新

### DIFF
--- a/content/page/ccc-coc.md
+++ b/content/page/ccc-coc.md
@@ -34,7 +34,7 @@ Japan Java User Group (JJUG) will enforce this code throughout the event.
 
 If you are being harassed, notice somebody else is being harassed, or have any other concerns, please contact a member of JJUG staff immediately.
 * Email: jjug.ccc@gmail.com
-* Web Form: https://forms.gle/XtFQiZbBwmKeS7h39
+* Web Form: https://forms.gle/VwubiUvZArLiMtEi9
 
 JJUG will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the event.
 We value your attendance.


### PR DESCRIPTION
ハラスメント報告用に使われるGoogle FormのURLが誤っているために権限エラーの表示となっていました。
そのため、正しく機能する公開リンクを取得したものに変更しています